### PR TITLE
Change to extension name podext

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,28 +8,28 @@ You can share start to share your ideas by opening Github issues at :
 https://github.com/podcloud/podcast-ext/issues
 
 ## Namespace
-The `podcast` namespace will be used to be fully platform agnostic and neutral.
+The `podext` namespace will be used to be fully platform agnostic and neutral.
 
 ## Podcast links
 
 A new set of tags will permit podcasters to add social and podcasting platforms informations
 
-- `podcast:platform` adds informations about where to find the podcast on podcast platforms (iTunes link, Spotify link, etc)
-- `podcast:social` adds urls to any social network related to the podcast
-- `podcast:donate` adds urls to a donation platform
-- `podcast:shop` adds urls to a shop
-- `podcast:link` can be used to add any other link related to the podcast
+- `podext:platform` adds informations about where to find the podcast on podcast platforms (iTunes link, Spotify link, etc)
+- `podext:social` adds urls to any social network related to the podcast
+- `podext:donate` adds urls to a donation platform
+- `podext:shop` adds urls to a shop
+- `podext:link` can be used to add any other link related to the podcast
 
 ## License
     
-- `podcast:license` tag should contain any license for the podcast (Creative Commons, private license, etc)
+- `podext:license` tag should contain any license for the podcast (Creative Commons, private license, etc)
 
 You can add this tag at channel level and item level.
 
 ## Platform blocks
 
 The feed owner can choose specificaly which podcasting platform is allowed or not to add the podcast to their catalog :
-`<podcast:block platform="PLATFORM_NAME">yes/no</podcast:block>`
+`<podext:block platform="PLATFORM_NAME">yes/no</podext:block>`
 
 A `default` platform name can be used to define the default behaviour an unlisted podcasting platform should adopt.
 
@@ -40,39 +40,39 @@ You can add this tag at channel level and item level.
 
 ## Team and Guests
 
-You can credit the people behind the podcast or an episode by using the `podcast:team` tag.
-Childrens of `podcast:team` tag can have a `role` attribute. (host, columnist, etc)
+You can credit the people behind the podcast or an episode by using the `podext:team` tag.
+Childrens of `podext:team` tag can have a `role` attribute. (host, columnist, etc)
 
-If you had guest on an episode, you can add them to the `podcast:guests` tag.
+If you had guest on an episode, you can add them to the `podext:guests` tag.
 
-Both tags is a list of `podcast:person` tags
+Both tags is a list of `podext:person` tags
 
 ## Persons
 
-A `podcast:person` tag can be used in `podcast:team` and `podcast:guest` lists. 
-This `podcast:person` tag can have childrens to add informations about their social networks or websites: 
-    `podcast:social`, `podcast:link`
+A `podext:person` tag can be used in `podext:team` and `podext:guest` lists. 
+This `podext:person` tag can have childrens to add informations about their social networks or websites: 
+    `podext:social`, `podext:link`
 
 This tag can also be used as a standalone tag on episodes metadata tags
 
 ## Episode metadata tags
 
 Any episodes can contains an infinite amount of tags to provide more data about the content of the episode.
-This include `podcast:person` if the episode is talking about a person (and said person is not a guest of the episode).
+This include `podext:person` if the episode is talking about a person (and said person is not a guest of the episode).
 
 This also include the following tags (with some attributes examples) : 
 
-- `podcast:book` with attributes `isbn`, `title`, `author`, `href` (link to the book on any website)
-- `podcast:game` with attributes `title`, `developer`, `publisher`, `platforms`, `href`
-- `podcast:tv_show` with attributes `title`, etc
-- `podcast:movie`
-- `podcast:music`
-- `podcast:art`
-- `podcast:object` (any object, a car, a computer, a furniture, a puree press etc..)
-- `podcast:location` with `name`, `lat`, `lng`, `address`, `city`, `postcode`, `country`
-- `podcast:website` for any website
-- `podcast:event` with `name` and `at` attributes, and with some childrens : `podcast:location`, `podcast:website`
-- `podcast:podcast` to add informations about any other podcast. Can use some childrens used at channel level : `podcast:platform`, `podcast:social` etc.
+- `podext:book` with attributes `isbn`, `title`, `author`, `href` (link to the book on any website)
+- `podext:game` with attributes `title`, `developer`, `publisher`, `platforms`, `href`
+- `podext:tv_show` with attributes `title`, etc
+- `podext:movie`
+- `podext:music`
+- `podext:art`
+- `podext:object` (any object, a car, a computer, a furniture, a puree press etc..)
+- `podext:location` with `name`, `lat`, `lng`, `address`, `city`, `postcode`, `country`
+- `podext:website` for any website
+- `podext:event` with `name` and `at` attributes, and with some childrens : `podext:location`, `podext:website`
+- `podext:podcast` to add informations about any other podcast. Can use some childrens used at channel level : `podext:platform`, `podext:social` etc.
 
 ## Status
 
@@ -86,67 +86,67 @@ Issues and pull requests are open.
 ## Example (first draft)
 
 ```xml
-<rss version="2.0" xmlns:podcast="https://podcast-ext.org">
+<rss version="2.0" xmlns:podext="https://podcast-ext.org">
 	<channel>
 		<!-- [...] -->
 
-		<podcast:platform platform="itunes" href="https://podcast.apple.com/mypodcast" />
-		<podcast:social platform="twitter" handle="pofmagicfingers" href="https://twitter.com/pofmagicfingers" />
-		<podcast:social platform="facebook" handle="pofmagicfingers" href="https://facebook.com/pofmagicfingers" />
-		<podcast:donate platform="patreon" handle="pofmagicfingers" href="https://patreon.com/pofmagicfingers" />
-		<podcast:shop platform="spreadshirt" href="https://spreadshirt.com/pofmagicfingers">Buy our stuff!</podcast:shop>
-		<podcast:link href="https://podcloud.app/user/pofmagicfingers">My podCloud profile</podcast:link>
+		<podext:platform platform="itunes" href="https://podcast.apple.com/mypodcast" />
+		<podext:social platform="twitter" handle="pofmagicfingers" href="https://twitter.com/pofmagicfingers" />
+		<podext:social platform="facebook" handle="pofmagicfingers" href="https://facebook.com/pofmagicfingers" />
+		<podext:donate platform="patreon" handle="pofmagicfingers" href="https://patreon.com/pofmagicfingers" />
+		<podext:shop platform="spreadshirt" href="https://spreadshirt.com/pofmagicfingers">Buy our stuff!</podext:shop>
+		<podext:link href="https://podcloud.app/user/pofmagicfingers">My podCloud profile</podext:link>
 
-		<podcast:block platform="itunes">yes</podcast:block>
-		<podcast:block platform="majelan">yes</podcast:block>
-		<podcast:block platform="googleplay">no</podcast:block>
-		<podcast:block platform="spotify">no</podcast:block>
-		<podcast:block platform="podcloud">yes</podcast:block>
+		<podext:block platform="itunes">yes</podext:block>
+		<podext:block platform="majelan">yes</podext:block>
+		<podext:block platform="googleplay">no</podext:block>
+		<podext:block platform="spotify">no</podext:block>
+		<podext:block platform="podcloud">yes</podext:block>
 
-		<podcast:team>
-			<podcast:person firstname="André" lastname="Michot" nickname="Michan" role="host" pronoun="they" />
-		</podcast:team>
+		<podext:team>
+			<podext:person firstname="André" lastname="Michot" nickname="Michan" role="host" pronoun="they" />
+		</podext:team>
 
 		<item>
 			<!-- [...] -->
-			<podcast:book isbn="1241234432" title="ABC" author="Michel" href="https://amazon.co.uk/azeaze" />
-			<podcast:game title="ABC" developer="Blizzard" publisher="Activision" />
-			<podcast:tv_show title="Stranger things" />
-			<podcast:movie title="ABC" director="André" />
-			<podcast:video title="ABC" href="https://vimeo.com/video/1234123" />
-			<podcast:music title="ABC" artist="Jackson5" href="https://music.com/abc" />
-			<podcast:art title="ABC" artist="Jackson5" href="https://music.com/abc" />
-			<podcast:object name="Model S" brand="Tesla" price="82500" currency="EUR" href="https://www.tesla.com/fr_FR/models" />
-			<podcast:person firstname="André" lastname="Michot" nickname="Michan" />
-			<podcast:person firstname="Michel" lastname="Maurice" nickname="Mimau">
-				<podcast:social platform="twitter" handle="mimau" />
-			</podcast:person>
+			<podext:book isbn="1241234432" title="ABC" author="Michel" href="https://amazon.co.uk/azeaze" />
+			<podext:game title="ABC" developer="Blizzard" publisher="Activision" />
+			<podext:tv_show title="Stranger things" />
+			<podext:movie title="ABC" director="André" />
+			<podext:video title="ABC" href="https://vimeo.com/video/1234123" />
+			<podext:music title="ABC" artist="Jackson5" href="https://music.com/abc" />
+			<podext:art title="ABC" artist="Jackson5" href="https://music.com/abc" />
+			<podext:object name="Model S" brand="Tesla" price="82500" currency="EUR" href="https://www.tesla.com/fr_FR/models" />
+			<podext:person firstname="André" lastname="Michot" nickname="Michan" />
+			<podext:person firstname="Michel" lastname="Maurice" nickname="Mimau">
+				<podext:social platform="twitter" handle="mimau" />
+			</podext:person>
 
-			<podcast:team>
-				<podcast:person firstname="André" lastname="Michot" nickname="Michan" role="host" />
-				<podcast:person firstname="Alexis" lastname="Blablo" nickname="blablo" role="columnist" />
-			</podcast:team>
+			<podext:team>
+				<podext:person firstname="André" lastname="Michot" nickname="Michan" role="host" />
+				<podext:person firstname="Alexis" lastname="Blablo" nickname="blablo" role="columnist" />
+			</podext:team>
 
-			<podcast:guests>
-				<podcast:person firstname="Thomas" lastname="Collins">
-					<podcast:link href="https://jaimelegif.com">Thomas project website</podcast:link>
-                    <podcast:social platform="twitter" handle="tomcol" href="https://twitter.com/tomcol" />
-				</podcast:person>
-			</podcast:guests>
+			<podext:guests>
+				<podext:person firstname="Thomas" lastname="Collins">
+					<podext:link href="https://jaimelegif.com">Thomas project website</podext:link>
+                    <podext:social platform="twitter" handle="tomcol" href="https://twitter.com/tomcol" />
+				</podext:person>
+			</podext:guests>
 
-			<podcast:location name="ABC" city="London" postcode="123VE" country="UK" lat="34.676637" lng="135.506512" />
-			<podcast:website name="Netflix" href="https://netflix.com" />
-			<podcast:event 
+			<podext:location name="ABC" city="London" postcode="123VE" country="UK" lat="34.676637" lng="135.506512" />
+			<podext:website name="Netflix" href="https://netflix.com" />
+			<podext:event 
 				name="MP3@Paris" 
 				when="Sat, 22 June 2019 10:00:00 CEST" 
 				where="Campus Jussieu" 
 				lat="48.847520"
 				lng="2.354047" 
 				href="https://mp3aparis.fr" />
-			<podcast:podcast name="P2P" href="https://p2p.lepodcast.fr" rss="https://p2p.lepodcast.fr/rss" />
-			<podcast:podcast name="P2P" href="https://p2p.lepodcast.fr" rss="https://p2p.lepodcast.fr/rss">
-				<podcast:platform platform="spotify" href="https://open.spotify.com/sdfsdf" />
-			</podcast:podcast>
+			<podext:podcast name="P2P" href="https://p2p.lepodcast.fr" rss="https://p2p.lepodcast.fr/rss" />
+			<podext:podcast name="P2P" href="https://p2p.lepodcast.fr" rss="https://p2p.lepodcast.fr/rss">
+				<podext:platform platform="spotify" href="https://open.spotify.com/sdfsdf" />
+			</podext:podcast>
 		</item>
 	</channel>
 </rss>


### PR DESCRIPTION
Podcast Index is using the podcast namespace as well, we should switch our namespace to prevent issues in future